### PR TITLE
use quick-csv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,24 +2,10 @@
 name = "rreverse"
 version = "0.1.0"
 dependencies = [
- "csv 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kdtree 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-csv 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "byteorder"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "csv"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -40,6 +26,14 @@ dependencies = [
 name = "libc"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quick-csv"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc-serialize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Grant Miner <xxgsoftware@gmail.com>"]
 
 [dependencies]
 kdtree = "~0.2.1"
-csv = "0.14.3"
+quick-csv = "0.1.4"
 rustc-serialize = "0.3"
 time = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 extern crate kdtree;
-extern crate csv;
+extern crate quick_csv;
 extern crate rustc_serialize;
 extern crate time;
 
@@ -26,10 +26,10 @@ impl Locations {
         let start = PreciseTime::now();
         let mut records = Vec::new();
 
-        let mut rdr = csv::Reader::from_file("cities.csv").unwrap();
+        let rdr = quick_csv::Csv::from_file("cities.csv").unwrap().has_header(true);
 
-        for record in rdr.decode() {
-            let r: Record = record.unwrap();
+        for record in rdr {
+            let r: Record = record.unwrap().decode().unwrap();
             records.push(([r.lat, r.lon], r));
         }
 


### PR DESCRIPTION
Gets tiny boost using quick-csv instead of csv

```
csv
$ time target/release/rreverse
PT0.355788687S seconds to load cities.csv
PT0.214264474S seconds to build the KdTree
(44.9483, -93.34801): Saint Louis Park Minnesota Hennepin County US

real    0m0.616s
user    0m0.548s
sys 0m0.068s
```

```
quick-csv
$ time target/release/rreverse
PT0.276284187S seconds to load cities.csv
PT0.212306487S seconds to build the KdTree
(44.9483, -93.34801): Saint Louis Park Minnesota Hennepin County US

real    0m0.539s
user    0m0.468s
sys 0m0.068s
```
