### PR TITLE
performance: switch to kiddo kd tree library for ~800x improvement on benchmark 😲

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,10 +906,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "kdtree"
-version = "0.6.0"
+name = "kiddo"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ee359328fc9087e9e3fc0a4567c4dd27ec69a127d6a70e8d9dd22845b8b1a2"
+checksum = "fc0a5c92307668140bf7d63a03a23e2da0b0453801fd54888c903cb7f723c293"
 dependencies = [
  "num-traits",
 ]
@@ -1378,7 +1378,7 @@ version = "3.0.0"
 dependencies = [
  "criterion",
  "csv",
- "kdtree",
+ "kiddo",
  "lazy_static",
  "serde",
  "serde_derive",

--- a/reverse-geocoder/Cargo.toml
+++ b/reverse-geocoder/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 ]
 
 [dependencies]
-kdtree = "^0.6"
+kiddo = "0.2"
 csv = "^1.1.6"
 #  time = "0.3.7"
 serde = "^1.0"


### PR DESCRIPTION
I tried a little experiment and switched out the old [kdtree](https://crates.io/crates/kdtree) library for [kiddo](https://crates.io/crates/kiddo), a performance-improved fork of the now 2-year-old kdtree. (fair disclosure: I'm the maintainer of kiddo).

This resulted in a huge improvement in performance on the benchmark. Tested on a Ryzen 5900X, I got the following result for the old master branch:

![image](https://user-images.githubusercontent.com/323439/165639052-4c0df306-a2f6-435b-94d8-8a942993bf44.png)

316.1 microseconds.

After my refactoring, I got the following result:

![image](https://user-images.githubusercontent.com/323439/165639187-1452985f-8896-4f7f-85c9-a50b1a8466a9.png)

409.9 nanoseconds - i.e. 0.4 microseconds! Faster by a factor of 790 😎 