### PR TITLE
crates.io patch to work around Kiddo dependency issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2024-03-02
+- Uses a crates.io patch to work around an [open issue with Kiddo](https://github.com/sdd/kiddo/issues/154) that prevents it from compiling.
+
 ## [4.1.0] - 2023-11-26
 - `from_path` returns `Result<ReverseGeocoder, std::io::Error>` now instead of `Result<ReverseGeocoder, Box<dyn error::Error>>`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reverse_geocoder"
-version = "4.0.0"
+version = "4.1.1"
 dependencies = [
  "criterion",
  "csv",

--- a/reverse-geocoder/Cargo.toml
+++ b/reverse-geocoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reverse_geocoder"
-version = "4.0.0"
+version = "4.1.1"
 authors = ["Grant Miner <gx0r@protonmail.com>"]
 edition = "2021"
 description = "Offline reverse geocoder library."
@@ -16,6 +16,10 @@ csv = "^1.3.0"
 #  time = "0.3.7"
 serde = "^1.0.193"
 serde_derive = "^1.0.193"
+
+[patch.crates-io]
+# https://github.com/sdd/kiddo/issues/154
+generator = { git = "https://github.com/Xudong-Huang/generator-rs", rev = "e3f16af" }
 
 [dev-dependencies]
 criterion = "^0.5.1"


### PR DESCRIPTION
There is an [open issue with Kiddo](https://github.com/sdd/kiddo/issues/154) which prevents Kiddo from compiling due to a dependency on generator-rs 0.7.6, which is broken. This forces the usage of generator-rs 0.7.5 which does not have this issue.